### PR TITLE
Update releaseFeedUrl

### DIFF
--- a/NpCloudinaryPlugin.php
+++ b/NpCloudinaryPlugin.php
@@ -78,7 +78,7 @@ class NpCloudinaryPlugin extends BasePlugin
 	 */
 	public function getReleaseFeedUrl()
 	{
-		return 'https://raw.githubusercontent.com/nilsenpaul/npcloudinary/npcloudinary/master/releases.json';
+		return 'https://raw.githubusercontent.com/nilsenpaul/npcloudinary/master/releases.json';
 	}
 
 	/**


### PR DESCRIPTION
Looks like the releaseFeedUrl needs updating to https://raw.githubusercontent.com/nilsenpaul/npcloudinary/master/releases.json.

It seemed to have an extra "npcloudinary" segment in there.